### PR TITLE
Add create first order card

### DIFF
--- a/lib/src/order/order_add.dart
+++ b/lib/src/order/order_add.dart
@@ -9,27 +9,27 @@ import 'package:subscriba/src/order/order_form.dart';
 import 'package:subscriba/src/store/subscriptions_model.dart';
 import 'package:subscriba/src/styles/styles.dart';
 
-class OrderEdit extends StatelessWidget {
-  static const routeName = '/order/edit';
-  final int orderId;
+class OrderAdd extends StatelessWidget {
+  static const routeName = '/order/add';
+  final int subscriptionId;
 
-  const OrderEdit({super.key, required this.orderId});
+  const OrderAdd({super.key, required this.subscriptionId});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text("Edit Order"),
+        title: const Text("Create Order"),
       ),
-      body: _Form(orderId: orderId),
+      body: _Form(subscriptionId: subscriptionId),
     );
   }
 }
 
 class _Form extends StatefulWidget {
-  final int orderId;
+  final int subscriptionId;
 
-  const _Form({super.key, required this.orderId});
+  const _Form({super.key, required this.subscriptionId});
 
   @override
   State<_Form> createState() => __FormState();
@@ -38,12 +38,6 @@ class _Form extends StatefulWidget {
 class __FormState extends State<_Form> with TickerProviderStateMixin {
   late final TabController paymentTypeTabController;
   final formModel = FormModel();
-  late Order originOrder;
-
-  Future<void> init() async {
-    originOrder = (await OrderProvider().getOrder(widget.orderId))!;
-    formModel.fromOrder(originOrder);
-  }
 
   @override
   void initState() {
@@ -59,10 +53,9 @@ class __FormState extends State<_Form> with TickerProviderStateMixin {
       formModel.validateAll(true);
 
       if (!formModel.error.hasErrors) {
-        await OrderProvider().update(
+        await OrderProvider().insert(
           Order.create(
-              id: originOrder.id,
-              subscriptionId: originOrder.subscriptionId,
+              subscriptionId: widget.subscriptionId,
               orderDate: formModel.startTimeTimestamp!,
               paymentType: formModel.paymentType,
               startDate: formModel.startTimeTimestamp!,
@@ -76,7 +69,7 @@ class __FormState extends State<_Form> with TickerProviderStateMixin {
 
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
-            content: Text('Successfully Updated'),
+            content: Text('Successfully Created'),
             behavior: SnackBarBehavior.floating,
           ),
         );
@@ -87,22 +80,14 @@ class __FormState extends State<_Form> with TickerProviderStateMixin {
       return false;
     }
 
-    return FutureBuilder(
-        future: init(),
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return Container();
-          }
-
-          return ListView(children: [
-            Padding(
-              padding: defaultCenterPadding.add(const EdgeInsets.only(top: 16)),
-              child: OrderForm(
-                formModel: formModel,
-                onSave: saveOrder,
-              ),
-            ),
-          ]);
-        });
+    return ListView(children: [
+      Padding(
+        padding: defaultCenterPadding.add(const EdgeInsets.only(top: 16)),
+        child: OrderForm(
+          formModel: formModel,
+          onSave: saveOrder,
+        ),
+      ),
+    ]);
   }
 }

--- a/lib/src/order/order_add.dart
+++ b/lib/src/order/order_add.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:provider/provider.dart';
 import 'package:subscriba/src/add_subscription/form_model.dart';
-import 'package:subscriba/src/add_subscription/lifetime_tab.dart';
-import 'package:subscriba/src/add_subscription/recurring_tab.dart';
 import 'package:subscriba/src/database/order.dart';
 import 'package:subscriba/src/order/order_form.dart';
 import 'package:subscriba/src/store/subscriptions_model.dart';

--- a/lib/src/order/order_edit.dart
+++ b/lib/src/order/order_edit.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:provider/provider.dart';
 import 'package:subscriba/src/add_subscription/form_model.dart';
-import 'package:subscriba/src/add_subscription/lifetime_tab.dart';
-import 'package:subscriba/src/add_subscription/recurring_tab.dart';
 import 'package:subscriba/src/database/order.dart';
 import 'package:subscriba/src/order/order_form.dart';
 import 'package:subscriba/src/store/subscriptions_model.dart';

--- a/lib/src/order/order_form.dart
+++ b/lib/src/order/order_form.dart
@@ -5,7 +5,6 @@ import 'package:subscriba/src/add_subscription/form_model.dart';
 import 'package:subscriba/src/add_subscription/lifetime_tab.dart';
 import 'package:subscriba/src/add_subscription/recurring_tab.dart';
 import 'package:subscriba/src/database/order.dart';
-import 'package:subscriba/src/order/order_edit.dart';
 
 typedef OnSave = Future<bool> Function();
 

--- a/lib/src/order/order_form.dart
+++ b/lib/src/order/order_form.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:provider/provider.dart';
+import 'package:subscriba/src/add_subscription/form_model.dart';
+import 'package:subscriba/src/add_subscription/lifetime_tab.dart';
+import 'package:subscriba/src/add_subscription/recurring_tab.dart';
+import 'package:subscriba/src/database/order.dart';
+import 'package:subscriba/src/order/order_edit.dart';
+
+typedef OnSave = Future<bool> Function();
+
+class OrderForm extends StatelessWidget {
+  const OrderForm({
+    super.key,
+    required this.formModel,
+    required this.onSave,
+  });
+
+  final FormModel formModel;
+  final OnSave onSave;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        children: [
+          SizedBox(
+            width: double.infinity,
+            child: Observer(builder: (context) {
+              return SegmentedButton<PaymentType>(
+                selected: <PaymentType>{formModel.paymentType},
+                segments: const [
+                  ButtonSegment(
+                      value: PaymentType.recurring, label: Text("Recurring")),
+                  ButtonSegment(
+                      value: PaymentType.lifetime, label: Text("Lifetime"))
+                ],
+                onSelectionChanged: (value) {
+                  formModel.setPaymentType(value.first);
+                },
+              );
+            }),
+          ),
+          const SizedBox(
+            height: 16,
+          ),
+          Provider(
+            create: (_) => formModel,
+            child: Observer(builder: (_) {
+              return formModel.paymentType == PaymentType.recurring
+                  ? const RecurringTab()
+                  : const LifetimeTab();
+            }),
+          ),
+          SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                  onPressed: () {
+                    onSave().then((isSuccess) {
+                      if (!isSuccess) return;
+                      Navigator.of(context).pop();
+                    });
+                  },
+                  child: const Text("Save"))),
+          const SizedBox(
+            height: 20,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/util/date_format_helper.dart
+++ b/lib/src/util/date_format_helper.dart
@@ -2,6 +2,7 @@ import 'package:intl/intl.dart';
 
 class DateFormatHelper {
   static String fromMicrosecondsSinceEpoch(int timestamp) {
+    if (timestamp == 0) return "";
     return DateFormat.yMd()
         .format(DateTime.fromMicrosecondsSinceEpoch(timestamp));
   }

--- a/lib/src/util/order_calculator.dart
+++ b/lib/src/util/order_calculator.dart
@@ -47,6 +47,8 @@ class OrderCalculator {
   }
 
   double perPrize(PaymentCycleType paymentCycleType) {
+    if (availableOrders.isEmpty) return 0;
+
     return availableOrders.map((e) {
           /**
        * 
@@ -64,7 +66,7 @@ perYear = 10 / 31 * 365 = 117.74..
                   e.paymentCycleType!, e.paymentPerPeriod) *
               paymentCycle2Days[paymentCycleType]!;
         }).fold(0.0, (value, element) => value + element) /
-        orders.length;
+        availableOrders.length;
   }
 
   bool get includeLifetimeOrder {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 新增了一个`OrderAdd` Flutter小部件，允许用户创建订阅订单。包括一个表单，用于输入订单详情，如支付类型、开始和结束日期以及每期支付金额。保存订单后，将订单插入数据库并更新订阅列表。
	- 引入了`OrderForm`类，提供了一个用于创建订单的表单，包括选择支付类型的分段按钮和每种订阅类型的标签页。
- **Bug修复**
	- 在`DateFormatHelper`类中添加了检查，如果输入的时间戳为0，则返回空字符串。
	- 在`OrderCalculator`类中，添加了对`availableOrders`列表为空的检查，确保在进行`perPrize`方法的计算时使用`availableOrders.length`而不是`orders.length`进行除法计算。
- **重构**
	- 在`order_edit.dart`中，移除了对`flutter_mobx`、`lifetime_tab`和`recurring_tab`的引用，添加了对`order_form`的引用。用简化的`OrderForm`小部件替换了复杂的UI结构，并添加了用于成功更新反馈的snackbar。
	- 在`subsciption_detail_view.dart`中，添加了对`order_add.dart`的引用，修改了`_SubscriptionDetailBody`小部件，根据可用订单条件显示`_CreateFirstOrderCard`，并根据可用订单条件显示`_RecurringCardsRow`。添加了`_CreateFirstOrderCard`小部件来处理无订单的情况，并重构了`_SubscriptionDetailHeader`小部件以显示订阅标题和描述。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->