### PR TITLE
feat: add MoneyText component to display formatted money values

### DIFF
--- a/lib/src/component/MoneyText.dart
+++ b/lib/src/component/MoneyText.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class MoneyText extends StatelessWidget {
+  const MoneyText({super.key, required this.money, this.style});
+
+  final double money;
+  final String currency = "\$";
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context) {
+    final usingStyle = style ?? Theme.of(context).textTheme.titleMedium!;
+    return Text(
+      "$currency${money == -1 ? '-' : money.toStringAsFixed(2)}",
+      style: usingStyle.copyWith(fontFamily: "Alibaba"),
+    );
+  }
+}

--- a/lib/src/subscriptions/subscriptions_app_bar.dart
+++ b/lib/src/subscriptions/subscriptions_app_bar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:provider/provider.dart';
+import 'package:subscriba/src/component/MoneyText.dart';
 import 'package:subscriba/src/store/subscriptions_model.dart';
 import 'package:subscriba/src/subscriptions/subscriptions_page_model.dart';
 import 'package:subscriba/src/util/order_calculator.dart';
@@ -47,10 +48,9 @@ class SubscriptionAppBar extends StatelessWidget
                     },
                     child: Row(
                       children: [
-                        Text(
-                          '\$${perMainPaymentCyclePrize.toStringAsFixed(2)}',
-                          style: Theme.of(context).textTheme.titleLarge,
-                        ),
+                        MoneyText(
+                            money: perMainPaymentCyclePrize,
+                            style: Theme.of(context).textTheme.titleLarge),
                         Text(
                           '/${PaymentCycleHelper.enum2FormalStr[subscriptionPageModel.paymentCycleType]!.toLowerCase()}',
                           style: Theme.of(context)


### PR DESCRIPTION
The MoneyText component is added to display formatted money values in the SubscriptionAppBar widget. It takes a 'money' parameter to specify the value to be displayed and an optional 'style' parameter to customize the text style. The component formats the money value with a currency symbol and two decimal places. If the value is -1, it displays a dash instead. The component uses the 'Alibaba' font family by default, but the style can be overridden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 新增了一个名为 `MoneyText` 的 Flutter 组件，用于以指定货币符号和样式显示货币值。
	- 在 `SubscriptionAppBar` 类中，引入了 `MoneyText` 组件以替代 `Text` 小部件，用于显示货币值。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->