### PR TITLE
feat: add auto-renewal functionality to subscription detail view

### DIFF
--- a/lib/src/about/about_view.dart
+++ b/lib/src/about/about_view.dart
@@ -7,6 +7,8 @@ import 'package:subscriba/src/database/model.dart';
 import 'package:subscriba/src/util/file_helper.dart';
 
 class AboutView extends StatelessWidget {
+  static const routeName = '/about';
+
   const AboutView({super.key});
 
   @override

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,13 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:subscriba/src/about/about_view.dart';
 import 'package:subscriba/src/add_subscription/add_subscription_view.dart';
 import 'package:subscriba/src/navigation.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:subscriba/src/store/subscriptions_model.dart';
+import 'package:subscriba/src/store_route_observer.dart';
 
 import 'settings/settings_controller.dart';
 import 'settings/settings_view.dart';
+
+final subscriptionsModel = SubscriptionsModel();
 
 /// The Widget that configures your application.
 class MyApp extends StatelessWidget {
@@ -31,7 +35,7 @@ class MyApp extends StatelessWidget {
     // The ListenableBuilder Widget listens to the SettingsController for changes.
     // Whenever the user updates their settings, the MaterialApp is rebuilt.
     return MultiProvider(
-      providers: [Provider(create: (_) => SubscriptionsModel())],
+      providers: [Provider(create: (_) => subscriptionsModel)],
       builder: (context, child) {
         return ListenableBuilder(
           listenable: settingsController,
@@ -71,6 +75,9 @@ class MyApp extends StatelessWidget {
               darkTheme: ThemeData.dark(useMaterial3: true),
               themeMode: ThemeMode.dark, //settingsController.themeMode,
 
+              navigatorObservers: [
+                StoreRouteObserver(subscriptionsModel: subscriptionsModel)
+              ],
               // Define a function to handle named routes in order to support
               // Flutter web url navigation and deep linking.
               onGenerateRoute: (RouteSettings routeSettings) {
@@ -82,6 +89,8 @@ class MyApp extends StatelessWidget {
                         return const AddSubscriptionView();
                       case SettingsView.routeName:
                         return SettingsView(controller: settingsController);
+                      case AboutView.routeName:
+                        return const AboutView();
                       default:
                         return const Navigation();
                     }

--- a/lib/src/store/subscription_model.dart
+++ b/lib/src/store/subscription_model.dart
@@ -1,6 +1,9 @@
+import 'package:flutter/material.dart';
 import 'package:mobx/mobx.dart';
 import 'package:subscriba/src/database/order.dart';
 import 'package:subscriba/src/database/subscription.dart';
+import 'package:subscriba/src/util/duration.dart';
+import 'package:subscriba/src/util/order_calculator.dart';
 
 part 'subscription_model.g.dart';
 
@@ -28,5 +31,48 @@ abstract class _SubscriptionModel with Store {
   Future<void> deleteOrder(int id) async {
     await OrderProvider().delete(id);
     reload();
+  }
+
+  /// 目前是在订阅将结束的当天或已经结束的时候进行自动续费
+  /// 新的订单会按设置的周期类型进行续费，分别对应1/31/365天（这里后期可以允许配置）
+  @action
+  Future<bool> tryRenew() async {
+    if (instance.orders.isEmpty) return false;
+    var orderCalculator = OrderCalculator(orders: instance.orders);
+    final expiresIn = orderCalculator.expiresIn;
+    if (!instance.isRenew || expiresIn == null || expiresIn.inDays > 0) {
+      return false;
+    }
+
+    while (orderCalculator.expiresIn!.inDays <= 0) {
+      final nextPaymentTemplate = orderCalculator.nextPaymentTemplate!;
+      final startDate =
+          DateTime.fromMicrosecondsSinceEpoch(nextPaymentTemplate.endDate!)
+              .add(const Duration(days: 1))
+              .microsecondsSinceEpoch;
+      final endDate = DateTime.fromMicrosecondsSinceEpoch(startDate)
+          .add(Duration(
+              days: DurationHelper
+                      .paymentCycle2Days[nextPaymentTemplate.paymentCycleType]!
+                      .toInt() -
+                  1))
+          .microsecondsSinceEpoch;
+
+      await OrderProvider().insert(
+        Order.create(
+          orderDate: startDate,
+          paymentType: nextPaymentTemplate.paymentType,
+          startDate: startDate,
+          endDate: endDate,
+          subscriptionId: instance.id,
+          paymentPerPeriodUnit: nextPaymentTemplate.paymentPerPeriodUnit,
+          paymentCycleType: nextPaymentTemplate.paymentCycleType,
+          paymentPerPeriod: nextPaymentTemplate.paymentPerPeriod,
+        ),
+      );
+      await reload();
+      orderCalculator = OrderCalculator(orders: instance.orders);
+    }
+    return true;
   }
 }

--- a/lib/src/store/subscription_model.dart
+++ b/lib/src/store/subscription_model.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:mobx/mobx.dart';
 import 'package:subscriba/src/database/order.dart';
 import 'package:subscriba/src/database/subscription.dart';

--- a/lib/src/store/subscription_model.g.dart
+++ b/lib/src/store/subscription_model.g.dart
@@ -49,6 +49,14 @@ mixin _$SubscriptionModel on _SubscriptionModel, Store {
     return _$deleteOrderAsyncAction.run(() => super.deleteOrder(id));
   }
 
+  late final _$tryRenewAsyncAction =
+      AsyncAction('_SubscriptionModel.tryRenew', context: context);
+
+  @override
+  Future<bool> tryRenew() {
+    return _$tryRenewAsyncAction.run(() => super.tryRenew());
+  }
+
   @override
   String toString() {
     return '''

--- a/lib/src/store/subscriptions_model.dart
+++ b/lib/src/store/subscriptions_model.dart
@@ -16,7 +16,8 @@ abstract class _SubscriptionsModel with Store {
   ObservableList<SubscriptionModel> subscriptions =
       ObservableList<SubscriptionModel>();
 
-  Map<int, SubscriptionModel> subscriptionsMap = {};
+  @observable
+  ObservableMap<int, SubscriptionModel> subscriptionsMap = ObservableMap();
 
   getSubscription(int id) {
     return subscriptionsMap[id];
@@ -29,6 +30,13 @@ abstract class _SubscriptionsModel with Store {
             .map((e) => SubscriptionModel(e))));
     for (var element in subscriptions) {
       subscriptionsMap[element.instance.id] = element;
+    }
+  }
+
+  @action
+  Future<void> tryRenewAll() async {
+    for (var element in subscriptions) {
+      await element.tryRenew();
     }
   }
 }

--- a/lib/src/store/subscriptions_model.g.dart
+++ b/lib/src/store/subscriptions_model.g.dart
@@ -25,6 +25,22 @@ mixin _$SubscriptionsModel on _SubscriptionsModel, Store {
     });
   }
 
+  late final _$subscriptionsMapAtom =
+      Atom(name: '_SubscriptionsModel.subscriptionsMap', context: context);
+
+  @override
+  ObservableMap<int, SubscriptionModel> get subscriptionsMap {
+    _$subscriptionsMapAtom.reportRead();
+    return super.subscriptionsMap;
+  }
+
+  @override
+  set subscriptionsMap(ObservableMap<int, SubscriptionModel> value) {
+    _$subscriptionsMapAtom.reportWrite(value, super.subscriptionsMap, () {
+      super.subscriptionsMap = value;
+    });
+  }
+
   late final _$loadSubscriptionsAsyncAction =
       AsyncAction('_SubscriptionsModel.loadSubscriptions', context: context);
 
@@ -33,10 +49,19 @@ mixin _$SubscriptionsModel on _SubscriptionsModel, Store {
     return _$loadSubscriptionsAsyncAction.run(() => super.loadSubscriptions());
   }
 
+  late final _$tryRenewAllAsyncAction =
+      AsyncAction('_SubscriptionsModel.tryRenewAll', context: context);
+
+  @override
+  Future<void> tryRenewAll() {
+    return _$tryRenewAllAsyncAction.run(() => super.tryRenewAll());
+  }
+
   @override
   String toString() {
     return '''
-subscriptions: ${subscriptions}
+subscriptions: ${subscriptions},
+subscriptionsMap: ${subscriptionsMap}
     ''';
   }
 }

--- a/lib/src/store_route_observer.dart
+++ b/lib/src/store_route_observer.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:subscriba/src/store/subscriptions_model.dart';
+
+class StoreRouteObserver extends RouteObserver<PageRoute<dynamic>> {
+  final SubscriptionsModel subscriptionsModel;
+
+  StoreRouteObserver({required this.subscriptionsModel});
+
+  @override
+  void didPush(Route route, Route? previousRoute) {
+    super.didPush(route, previousRoute);
+    subscriptionsModel.loadSubscriptions();
+  }
+}

--- a/lib/src/subscription/subscription_card.dart
+++ b/lib/src/subscription/subscription_card.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:provider/provider.dart';
 import 'package:subscriba/src/database/order.dart';
 import 'package:subscriba/src/store/subscription_model.dart';
 import 'package:subscriba/src/subscription/subscription_per_prize.dart';

--- a/lib/src/subscription/subscription_card.dart
+++ b/lib/src/subscription/subscription_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:provider/provider.dart';
 import 'package:subscriba/src/database/order.dart';
 import 'package:subscriba/src/store/subscription_model.dart';
 import 'package:subscriba/src/subscription/subscription_per_prize.dart';
@@ -20,8 +21,10 @@ class SubscriptionCard extends StatelessWidget {
           context,
           MaterialPageRoute(
               builder: (context) => SubscriptionDetailView(
-                    subscription: subscription,
-                  )),
+                  subscriptionId: subscription.instance.id),
+              settings: const RouteSettings(
+                name: SubscriptionDetailView.routeName,
+              )),
         );
       },
       child: Card(

--- a/lib/src/subscription_detail/subscription_detail_view.dart
+++ b/lib/src/subscription_detail/subscription_detail_view.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:mobx/mobx.dart';
 import 'package:provider/provider.dart';
 import 'package:subscriba/src/component/section.dart';
 import 'package:subscriba/src/database/order.dart';

--- a/lib/src/util/duration.dart
+++ b/lib/src/util/duration.dart
@@ -28,6 +28,12 @@ class DurationHelper {
   static const double dayPerMonth = 31; //dayPerYear / 12;
   static const double dayPerYear = 365;
 
+  static const paymentCycle2Days = {
+    PaymentCycleType.daily: 1.0,
+    PaymentCycleType.monthly: DurationHelper.dayPerMonth,
+    PaymentCycleType.yearly: DurationHelper.dayPerYear
+  };
+
   double toDays() {
     if (unit == PaymentCycleType.daily) {
       return duration.toDouble();


### PR DESCRIPTION
The `SubscriptionModel` class now has a new method `tryRenew()` which attempts to automatically renew a subscription when it is about to expire. The method checks if the subscription has any orders and if the auto-renewal setting is enabled. If both conditions are met, it calculates the expiration date of the next payment template and creates a new order with the appropriate start and end dates. The method continues to create new orders until the expiration date is in the future. 

In the `SubscriptionDetailView` class, the `subscription` property is now a `Future<SubscriptionModel>` instead of a `SubscriptionModel`. The `subscription` property is fetched asynchronously using the `_getSubscription()` method, which retrieves the subscription data from the provider. The `build()` method now uses a `FutureBuilder` to handle the asynchronous loading of the subscription data. Once the data is available, the `tryRenew()` method is called

resolve #18 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
    - 在应用中添加了“关于”页面的路由。
    - 引入了基于条件的自动续订功能，增强了订阅管理体验。
- **改进**
    - 订阅详情现在支持异步数据加载，提升了用户界面响应性和数据处理能力。
    - 优化了支付周期和到期处理的文档说明，提高了代码的可读性和易理解性。
- **修复**
    - 调整了导航逻辑，确保正确传递订阅ID，解决了潜在的导航问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->