### PR TITLE
refactor: optimize calculation of subscription costs using OrderCalculator class and introduce MoneyText component for displaying money values

### DIFF
--- a/lib/src/add_subscription/recurring_tab.dart
+++ b/lib/src/add_subscription/recurring_tab.dart
@@ -167,15 +167,15 @@ class RecurringTab extends StatelessWidget {
                   final dailyCost = formModel.paymentPerPeriodText == null
                       ? 0.0
                       : orderCalculator
-                          .perPrizeByProtocol(PaymentCycleType.daily);
+                          .perCostByProtocol(PaymentCycleType.daily);
                   final monthlyCost = formModel.paymentPerPeriodText == null
                       ? 0.0
                       : orderCalculator
-                          .perPrizeByProtocol(PaymentCycleType.monthly);
+                          .perCostByProtocol(PaymentCycleType.monthly);
                   final annuallyCost = formModel.paymentPerPeriodText == null
                       ? 0.0
                       : orderCalculator
-                          .perPrizeByProtocol(PaymentCycleType.yearly);
+                          .perCostByProtocol(PaymentCycleType.yearly);
                   return PerPeriodCostCardsRow(
                       dailyCost: dailyCost,
                       monthlyCost: monthlyCost,

--- a/lib/src/component/money_text.dart
+++ b/lib/src/component/money_text.dart
@@ -1,17 +1,19 @@
 import 'package:flutter/material.dart';
 
 class MoneyText extends StatelessWidget {
-  const MoneyText({super.key, required this.money, this.style});
+  const MoneyText(
+      {super.key, required this.money, this.style, this.suffix = ""});
 
   final double money;
   final String currency = "\$";
   final TextStyle? style;
+  final String suffix;
 
   @override
   Widget build(BuildContext context) {
     final usingStyle = style ?? Theme.of(context).textTheme.titleMedium!;
     return Text(
-      "$currency${money == -1 ? '-' : money.toStringAsFixed(2)}",
+      "$currency${money == -1 ? '-' : money.toStringAsFixed(2)}$suffix",
       style: usingStyle.copyWith(fontFamily: "Alibaba"),
     );
   }

--- a/lib/src/home/home_app_bar.dart
+++ b/lib/src/home/home_app_bar.dart
@@ -6,6 +6,7 @@ import 'package:subscriba/src/store/subscriptions_model.dart';
 import 'package:subscriba/src/subscriptions/subscriptions_page_model.dart';
 import 'package:subscriba/src/util/order_calculator.dart';
 import 'package:subscriba/src/util/payment_cycle.dart';
+import 'package:subscriba/src/util/subscription_calculator.dart';
 
 class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
   const HomeAppBar({super.key});
@@ -24,14 +25,11 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
         child: Column(
           children: [
             Observer(builder: (context) {
-              final perMainPaymentCyclePrize =
-                  subscriptionsModel.subscriptions.map(
-                (e) {
-                  return OrderCalculator(orders: e.instance.orders)
-                      .perPrizeByProtocol(
-                          subscriptionPageModel.paymentCycleType);
-                },
-              ).fold(0.0, (value, element) => value + element);
+              final perMainPaymentCyclePrize = SubscriptionCalculator(
+                      subscriptions: subscriptionsModel.subscriptions
+                          .map((e) => e.instance)
+                          .toList())
+                  .perPrizeByProtocol(subscriptionPageModel.paymentCycleType);
               return InkWell(
                 onTap: () {
                   subscriptionPageModel.toNextPaymentCycleType();

--- a/lib/src/home/home_app_bar.dart
+++ b/lib/src/home/home_app_bar.dart
@@ -4,7 +4,6 @@ import 'package:provider/provider.dart';
 import 'package:subscriba/src/component/money_text.dart';
 import 'package:subscriba/src/store/subscriptions_model.dart';
 import 'package:subscriba/src/subscriptions/subscriptions_page_model.dart';
-import 'package:subscriba/src/util/order_calculator.dart';
 import 'package:subscriba/src/util/payment_cycle.dart';
 import 'package:subscriba/src/util/subscription_calculator.dart';
 

--- a/lib/src/subscription/subscription_per_prize.dart
+++ b/lib/src/subscription/subscription_per_prize.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:subscriba/src/component/money_text.dart';
 import 'package:subscriba/src/database/order.dart';
 import 'package:subscriba/src/store/subscription_model.dart';
 import 'package:subscriba/src/util/order_calculator.dart';
@@ -20,40 +21,46 @@ class SubscriptionPerPrize extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final perMainPaymentCyclePrize =
-        OrderCalculator(orders: subscription.instance.orders)
-            .perPrizeByProtocol(mainPaymentCycleType);
+    final orderCalculator =
+        OrderCalculator(orders: subscription.instance.orders);
+    final perMainPaymentCyclePrize = orderCalculator.isIncludeLifetimeOrder
+        ? orderCalculator.lifetimeCost
+        : orderCalculator.perCostByProtocol(mainPaymentCycleType);
     final perDayPaymentCyclePrize =
-        OrderCalculator(orders: subscription.instance.orders)
-            .perPrizeByProtocol(PaymentCycleType.daily);
+        orderCalculator.perCostByProtocol(PaymentCycleType.daily);
 
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
         Row(children: [
-          Text(
-            "\$${perMainPaymentCyclePrize.toStringAsFixed(2)}",
-            style: Theme.of(context)
-                .textTheme
-                .titleMedium!
-                .copyWith(fontFamily: "Alibaba"),
+          MoneyText(
+            money: perMainPaymentCyclePrize,
+            style: Theme.of(context).textTheme.titleMedium,
           ),
-          Text(
-            "/${paymentCycleType2Display[mainPaymentCycleType]}",
-            style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
-                ),
-          )
+          !orderCalculator.isIncludeLifetimeOrder
+              ? Text(
+                  "/${paymentCycleType2Display[mainPaymentCycleType]}",
+                  style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                )
+              : const SizedBox.shrink()
         ]),
-        mainPaymentCycleType != PaymentCycleType.daily
-            ? Text(
-                "\$${perDayPaymentCyclePrize.toStringAsFixed(2)}/day",
+        orderCalculator.isIncludeLifetimeOrder
+            ? Text("lifetime",
                 style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    fontFamily: "Alibaba"),
-              )
-            : Container()
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ))
+            : mainPaymentCycleType != PaymentCycleType.daily
+                ? MoneyText(
+                    money: perDayPaymentCyclePrize,
+                    style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                    suffix: "/day",
+                  )
+                : Container()
       ],
     );
   }

--- a/lib/src/subscription_detail/subscription_detail_view.dart
+++ b/lib/src/subscription_detail/subscription_detail_view.dart
@@ -274,6 +274,7 @@ class _NextPaymentCard extends StatelessWidget {
             OrderCalculator(orders: subscription.instance.orders);
         final isRenew = subscription.instance.isRenew;
         // TODO 永久订阅时的展示
+        // ignore: unused_local_variable
         final isLifetime = OrderCalculator(orders: subscription.instance.orders)
             .isIncludeLifetimeOrder;
 

--- a/lib/src/subscription_detail/subscription_detail_view.dart
+++ b/lib/src/subscription_detail/subscription_detail_view.dart
@@ -145,9 +145,9 @@ class _SubscriptionDetailBody extends StatelessWidget {
                   OrderCalculator(orders: subscription.instance.orders);
 
               double calculateCost(PaymentCycleType cycleType) {
-                return orderCalculator.includeLifetimeOrder
-                    ? orderCalculator.perPrizeByActual(cycleType)
-                    : orderCalculator.perPrizeByProtocol(cycleType);
+                return orderCalculator.isIncludeLifetimeOrder
+                    ? orderCalculator.perCostByActual(cycleType)
+                    : orderCalculator.perCostByProtocol(cycleType);
               }
 
               return Padding(
@@ -241,7 +241,7 @@ class _RecurringCardsRow extends StatelessWidget {
     return Observer(
       builder: (_) {
         final isLifetime = OrderCalculator(orders: subscription.instance.orders)
-            .includeLifetimeOrder;
+            .isIncludeLifetimeOrder;
 
         if (isLifetime) {
           return Container();
@@ -275,7 +275,7 @@ class _NextPaymentCard extends StatelessWidget {
         final isRenew = subscription.instance.isRenew;
         // TODO 永久订阅时的展示
         final isLifetime = OrderCalculator(orders: subscription.instance.orders)
-            .includeLifetimeOrder;
+            .isIncludeLifetimeOrder;
 
         return Expanded(
             flex: 2,
@@ -332,7 +332,7 @@ class _RenewCard extends StatelessWidget {
       builder: (_) {
         final isRenew = subscription.instance.isRenew;
         final isLifetime = OrderCalculator(orders: subscription.instance.orders)
-            .includeLifetimeOrder;
+            .isIncludeLifetimeOrder;
 
         final onTap = isLifetime
             ? null
@@ -382,7 +382,7 @@ class _TotallyCostCard extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(
-                "\$${OrderCalculator(orders: subscription.instance.orders).totalPrize}",
+                "\$${OrderCalculator(orders: subscription.instance.orders).totalCost}",
                 style: Theme.of(context)
                     .textTheme
                     .titleMedium!

--- a/lib/src/subscriptions/subscriptions_app_bar.dart
+++ b/lib/src/subscriptions/subscriptions_app_bar.dart
@@ -6,6 +6,7 @@ import 'package:subscriba/src/store/subscriptions_model.dart';
 import 'package:subscriba/src/subscriptions/subscriptions_page_model.dart';
 import 'package:subscriba/src/util/order_calculator.dart';
 import 'package:subscriba/src/util/payment_cycle.dart';
+import 'package:subscriba/src/util/subscription_calculator.dart';
 
 class SubscriptionAppBar extends StatelessWidget
     implements PreferredSizeWidget {
@@ -34,14 +35,12 @@ class SubscriptionAppBar extends StatelessWidget
                           style: Theme.of(context).textTheme.titleLarge,
                         )),
                 Observer(builder: (_) {
-                  final perMainPaymentCyclePrize =
-                      subscriptionsModel.subscriptions.map(
-                    (e) {
-                      return OrderCalculator(orders: e.instance.orders)
-                          .perPrizeByProtocol(
-                              subscriptionPageModel.paymentCycleType);
-                    },
-                  ).fold(0.0, (value, element) => value + element);
+                  final perMainPaymentCyclePrize = SubscriptionCalculator(
+                          subscriptions: subscriptionsModel.subscriptions
+                              .map((e) => e.instance)
+                              .toList())
+                      .perPrizeByProtocol(
+                          subscriptionPageModel.paymentCycleType);
                   return InkWell(
                     onTap: () {
                       subscriptionPageModel.toNextPaymentCycleType();

--- a/lib/src/subscriptions/subscriptions_app_bar.dart
+++ b/lib/src/subscriptions/subscriptions_app_bar.dart
@@ -4,7 +4,6 @@ import 'package:provider/provider.dart';
 import 'package:subscriba/src/component/money_text.dart';
 import 'package:subscriba/src/store/subscriptions_model.dart';
 import 'package:subscriba/src/subscriptions/subscriptions_page_model.dart';
-import 'package:subscriba/src/util/order_calculator.dart';
 import 'package:subscriba/src/util/payment_cycle.dart';
 import 'package:subscriba/src/util/subscription_calculator.dart';
 

--- a/lib/src/util/subscription_calculator.dart
+++ b/lib/src/util/subscription_calculator.dart
@@ -1,0 +1,29 @@
+import 'package:subscriba/src/database/order.dart';
+import 'package:subscriba/src/database/subscription.dart';
+import 'package:subscriba/src/util/order_calculator.dart';
+
+class SubscriptionCalculator {
+  const SubscriptionCalculator({required this.subscriptions});
+
+  final List<Subscription> subscriptions;
+
+  List<Subscription> get availableSubscriptions {
+    final result =
+        subscriptions.where((element) => element.deletedAt == null).toList();
+    return result;
+  }
+
+  /// 协议均值算法，累加每个subscription的均值
+  /// lifetime订单会被忽略
+  double perPrizeByProtocol(PaymentCycleType paymentCycleType) {
+    if (availableSubscriptions.isEmpty) return 0;
+
+    return availableSubscriptions
+        .map((e) {
+          return OrderCalculator(orders: e.orders)
+              .perCostByProtocol(paymentCycleType);
+        })
+        .where((element) => element != -1)
+        .fold(0.0, (previousValue, element) => previousValue + element);
+  }
+}


### PR DESCRIPTION
resolve #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
    - 在`MoneyText`组件中新增了一个可选的`suffix`参数，允许自定义显示的金额文本后缀，增强了组件的灵活性。
    - 引入了`SubscriptionCalculator`类，用于基于支付周期计算订阅的平均成本，提高了订阅成本计算的准确性和效率。

- **Bug修复**
    - 更新了`RecurringTab`类中的方法调用，从`perPrizeByProtocol`更改为`perCostByProtocol`，以正确反映不同支付周期类型的成本。
    - 在`HomeAppBar`和`SubscriptionAppBar`类中，计算逻辑现使用`SubscriptionCalculator`替代`OrderCalculator`，优化了订阅成本的计算方式。
    - 在`SubscriptionPerPrize`类中，对`perMainPaymentCyclePrize`的计算进行了重构，现在能够考虑终身订单，同时更新了支付周期类型的显示逻辑，并引入了`MoneyText`组件以保持金钱显示的一致性。
    - 在`subscription_detail_view.dart`文件中，更新了对`OrderCalculator`属性的引用和方法调用，从而更准确地计算和显示订阅成本及终身订单。

- **重构**
    - `order_calculator.dart`文件中的功能已更新，反映了从计算奖金相关值到成本相关值的转变，包括重命名相关函数和变量，引入了一个新方法来计算终身成本，并调整了处理终身订单的逻辑。
    - 引入了`SubscriptionCalculator`类，替代了原有的计算逻辑，提高了代码的可维护性和扩展性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->