### PR TITLE
fix: update default description for order to "Lifetime subscription" in OrderCard class

### DIFF
--- a/lib/src/component/money_text.dart
+++ b/lib/src/component/money_text.dart
@@ -2,19 +2,26 @@ import 'package:flutter/material.dart';
 
 class MoneyText extends StatelessWidget {
   const MoneyText(
-      {super.key, required this.money, this.style, this.suffix = ""});
+      {super.key,
+      required this.money,
+      this.style,
+      this.suffix = "",
+      this.showLineThrough = false});
 
   final double money;
   final String currency = "\$";
   final TextStyle? style;
   final String suffix;
+  final bool showLineThrough;
 
   @override
   Widget build(BuildContext context) {
     final usingStyle = style ?? Theme.of(context).textTheme.titleMedium!;
     return Text(
       "$currency${money == -1 ? '-' : money.toStringAsFixed(2)}$suffix",
-      style: usingStyle.copyWith(fontFamily: "Alibaba"),
+      style: usingStyle.copyWith(
+          fontFamily: "Alibaba",
+          decoration: showLineThrough ? TextDecoration.lineThrough : null),
     );
   }
 }

--- a/lib/src/home/home_body.dart
+++ b/lib/src/home/home_body.dart
@@ -9,7 +9,7 @@ class HomeBody extends StatelessWidget {
     return const SingleChildScrollView(
       child: Column(
         children: [
-          HomeSubscriptionSection(),
+          MostExpensiveSubscriptionSection(),
           // HomeSubscriptionSection(),
           // HomeSubscriptionSection()
         ],

--- a/lib/src/order/order_card.dart
+++ b/lib/src/order/order_card.dart
@@ -26,7 +26,7 @@ class OrderCard extends StatelessWidget {
 
         final description = order.description ??
             paymentFrequency2Description[order.paymentFrequency] ??
-            "";
+            "Lifetime subscription";
 
         Future<bool?> showConfirmDialog() async {
           return await showDialog<bool>(

--- a/lib/src/store/subscription_model.dart
+++ b/lib/src/store/subscription_model.dart
@@ -39,7 +39,10 @@ abstract class _SubscriptionModel with Store {
     if (instance.orders.isEmpty) return false;
     var orderCalculator = OrderCalculator(orders: instance.orders);
     final expiresIn = orderCalculator.expiresIn;
-    if (!instance.isRenew || expiresIn == null || expiresIn.inDays > 0) {
+    if (!instance.isRenew ||
+        expiresIn == null ||
+        expiresIn.inDays > 0 ||
+        orderCalculator.nextPaymentTemplate == null) {
       return false;
     }
 

--- a/lib/src/subscription/subscription_per_prize.dart
+++ b/lib/src/subscription/subscription_per_prize.dart
@@ -33,20 +33,30 @@ class SubscriptionPerPrize extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.center,
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        Row(children: [
-          MoneyText(
-            money: perMainPaymentCyclePrize,
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          !orderCalculator.isIncludeLifetimeOrder
-              ? Text(
-                  "/${paymentFrequency2Display[mainPaymentFrequency]}",
-                  style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      ),
-                )
-              : const SizedBox.shrink()
-        ]),
+        orderCalculator.isExpired
+            ? Text(
+                "Expired",
+                style: Theme.of(context)
+                    .textTheme
+                    .titleMedium!
+                    .copyWith(color: Theme.of(context).colorScheme.error),
+              )
+            : Row(children: [
+                MoneyText(
+                  money: perMainPaymentCyclePrize,
+                  style: Theme.of(context).textTheme.titleMedium!.copyWith(),
+                ),
+                !orderCalculator.isIncludeLifetimeOrder
+                    ? Text(
+                        "/${paymentFrequency2Display[mainPaymentFrequency]}",
+                        style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .onSurfaceVariant,
+                            ),
+                      )
+                    : const SizedBox.shrink()
+              ]),
         orderCalculator.isIncludeLifetimeOrder
             ? Text("lifetime",
                 style: Theme.of(context).textTheme.bodySmall!.copyWith(
@@ -59,6 +69,7 @@ class SubscriptionPerPrize extends StatelessWidget {
                           color: Theme.of(context).colorScheme.onSurfaceVariant,
                         ),
                     suffix: "/day",
+                    showLineThrough: orderCalculator.isExpired,
                   )
                 : Container()
       ],

--- a/lib/src/subscription_detail/subscription_detail_view.dart
+++ b/lib/src/subscription_detail/subscription_detail_view.dart
@@ -548,12 +548,14 @@ class _SubscriptionTimeInfoCard extends StatelessWidget {
                             backgroundColor:
                                 Theme.of(context).colorScheme.surfaceVariant,
                             label: Text(
-                                isExpired(expiresIn) ? "Expired" : "Active",
+                                orderCalculator.isExpired
+                                    ? "Expired"
+                                    : "Active",
                                 style: Theme.of(context)
                                     .textTheme
                                     .labelMedium!
                                     .copyWith(
-                                        color: isExpired(expiresIn)
+                                        color: orderCalculator.isExpired
                                             ? Theme.of(context)
                                                 .colorScheme
                                                 .tertiary
@@ -601,9 +603,6 @@ class _SubscriptionTimeInfoCard extends StatelessWidget {
       },
     );
   }
-
-  bool isExpired(Duration? expiresIn) =>
-      expiresIn != null && expiresIn.inDays < 0;
 }
 
 class _SubscriptionDetailHeader extends StatelessWidget {

--- a/lib/src/subscriptions/subscriptions_app_bar.dart
+++ b/lib/src/subscriptions/subscriptions_app_bar.dart
@@ -30,7 +30,7 @@ class SubscriptionAppBar extends StatelessWidget
               children: [
                 Observer(
                     builder: (_) => Text(
-                          'A total of ${subscriptionsModel.subscriptions.length}',
+                          '${subscriptionsModel.subscriptions.length} Subscriptions',
                           style: Theme.of(context).textTheme.titleLarge,
                         )),
                 Observer(builder: (_) {

--- a/lib/src/util/order_calculator.dart
+++ b/lib/src/util/order_calculator.dart
@@ -1,5 +1,3 @@
-import 'dart:ffi';
-
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:subscriba/src/database/order.dart';

--- a/lib/src/util/order_calculator.dart
+++ b/lib/src/util/order_calculator.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi';
+
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:subscriba/src/database/order.dart';
@@ -236,9 +238,18 @@ class OrderCalculator {
         .difference(nowDate);
   }
 
+  bool get isExpired {
+    return expiresIn != null && expiresIn!.inDays < 0;
+  }
+
   /// 获取用于自动续订的订单模板（以最后一次订单为准）
   Order? get nextPaymentTemplate {
     if (isIncludeLifetimeOrder || availableOrders.isEmpty) {
+      return null;
+    }
+
+    if (availableOrders[availableOrders.length - 1].paymentFrequency ==
+        PaymentFrequency.oneTime) {
       return null;
     }
 

--- a/lib/src/util/subscription_calculator.dart
+++ b/lib/src/util/subscription_calculator.dart
@@ -15,10 +15,12 @@ class SubscriptionCalculator {
 
   /// 协议均值算法，累加每个subscription的均值
   /// lifetime订单会被忽略
+  /// 已经过期的订单会被忽略
   double perPrizeByProtocol(PaymentFrequency paymentFrequency) {
     if (availableSubscriptions.isEmpty) return 0;
 
     return availableSubscriptions
+        .where((element) => !OrderCalculator(orders: element.orders).isExpired)
         .map((e) {
           return OrderCalculator(orders: e.orders)
               .perCostByProtocol(paymentFrequency);


### PR DESCRIPTION
feat: add sorting logic to display top 3 most expensive subscriptions in MostExpensiveSubscriptionSection

feat: add logic to exclude expired orders in perPrizeByProtocol method of SubscriptionCalculator

feat: add logic to exclude expired orders in _SubscriptionModel class

feat: add isExpired property to OrderCalculator class

refactor: add null check for nextPaymentTemplate in OrderCalculator class

refactor: import dart:ffi in file to fix compilation issue

resolve #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在 `MoneyText` 类中增加了一个可选参数 `showLineThrough`，用以控制文字是否显示删除线。
	- 引入了“最昂贵订阅部分”替换原有的“首页订阅部分”，展示内容有所变更。
	- 更新了订阅列表，现在按平均价格降序排列，仅显示前三个非终身和未过期的订阅。
	- 对订阅奖励的显示逻辑进行了更新，如果订阅已过期，则显示“已过期”并应用错误样式；否则显示奖励金额和频率信息。

- **Bug修复**
	- 在某些条件下，`OrderCard` 类的 `description` 字段默认值更改为“终身订阅”。
	- 修复了根据订阅过期状态更改标签文本逻辑的方法。

- **改进**
	- 在 `SubscriptionAppBar` 类中更新了显示的文本，现在在订阅数量后包含“订阅”以提高清晰度。
	- 增加了判断订单是否过期的属性，基于其到期日期。
	- 更新了确定 `nextPaymentTemplate` 的逻辑，排除了一次性支付频率的订单。
	- 当计算基于支付频率的订阅平均值时，添加了忽略过期订单的条件。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->